### PR TITLE
Append semi-colon if not present at end of atyle attr.

### DIFF
--- a/ckeditor_span_merge.py
+++ b/ckeditor_span_merge.py
@@ -6,9 +6,13 @@ def span_scan(span, level=0):
         child = span.find("span")
         child_style = ""
         if child:
-            child_style = span_scan(child, level+1)
+            child_style = span_scan(child, level+1).strip()
+            if not child_style.endswith(";"):
+                child_style += ";"
 
-        this_style = span.attrs.get("style")
+        this_style = span.attrs.get("style").strip()
+        if not this_style.endswith(";"):
+            this_style += ";"
         if level != 0:
             span.unwrap()
 


### PR DESCRIPTION
Not all style attributes have a semi-colon at the end, so we need to append one, so that when we join all the different styles, that it ends up being valid CSS.